### PR TITLE
Handle yml files in list_roles

### DIFF
--- a/GPT_RP.py
+++ b/GPT_RP.py
@@ -119,7 +119,11 @@ async def health():
 
 @router.get("/list_roles")
 async def list_roles():
-    roles = [f[:-5] for f in os.listdir(CHAR_DIR) if f.endswith(".yaml")]
+    roles = []
+    for f in os.listdir(CHAR_DIR):
+        base, ext = os.path.splitext(f)
+        if ext.lower() in (".yaml", ".yml"):
+            roles.append(base)
     return {"roles": roles}
 
 # --------------------


### PR DESCRIPTION
## Summary
- support both `.yaml` and `.yml` extensions when listing roles

## Testing
- `python -m py_compile GPT_RP.py`
- `python - <<'PY'
import GPT_RP
PY
` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685cbc24d008832fb6d5ecfa4aed16a5