### PR TITLE
Fix character path handling

### DIFF
--- a/GPT_RP.py
+++ b/GPT_RP.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Optional, List
 from datetime import datetime, timezone
-import os
+from pathlib import Path
 import yaml
 
 """
@@ -23,7 +23,7 @@ GPT_RP.py — 多角色混戰（N 角色一次回覆）
 # --------------------
 # 常數設定
 # --------------------
-CHAR_DIR = "characters"       # 存放角色卡的資料夾
+CHAR_DIR = Path("characters")  # 存放角色卡的資料夾
 DEFAULT_CHAR = "lazul"        # 沒帶 characters 時的預設角色
 
 # --------------------
@@ -56,17 +56,23 @@ def load_character_yaml(char_name: str):
     """
     # 支援大小寫與 .yml / .yaml
     lc_name = char_name.lower()
-    candidates = [
-        os.path.join(CHAR_DIR, f"{lc_name}.yaml"),
-        os.path.join(CHAR_DIR, f"{lc_name}.yml"),
-    ]
-    path = next((p for p in candidates if os.path.exists(p)), None)
+
+    # 拒絕含路徑分隔符的輸入，避免逃離角色資料夾
+    if Path(lc_name).name != lc_name:
+        raise HTTPException(status_code=400, detail="非法角色卡路徑！")
+
+    candidates = [CHAR_DIR / f"{lc_name}.yaml", CHAR_DIR / f"{lc_name}.yml"]
+    path = next((p for p in candidates if p.exists()), None)
     if not path:
         raise HTTPException(status_code=404, detail=f"角色卡 {char_name} 不存在！")
-    if not os.path.exists(path):
-        raise HTTPException(status_code=404, detail=f"角色卡 {char_name}.yaml 不存在！")
 
-    with open(path, "r", encoding="utf-8") as f:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(CHAR_DIR.resolve())
+    except ValueError:
+        raise HTTPException(status_code=400, detail="角色卡路徑越界！")
+
+    with open(resolved, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
     # 最少需要 basic_info / speech_patterns 兩塊, 否則視為配置錯誤
@@ -120,10 +126,9 @@ async def health():
 @router.get("/list_roles")
 async def list_roles():
     roles = []
-    for f in os.listdir(CHAR_DIR):
-        base, ext = os.path.splitext(f)
-        if ext.lower() in (".yaml", ".yml"):
-            roles.append(base)
+    for f in CHAR_DIR.iterdir():
+        if f.suffix.lower() in (".yaml", ".yml"):
+            roles.append(f.stem)
     return {"roles": roles}
 
 # --------------------


### PR DESCRIPTION
## Summary
- use `Path` objects for character directory management
- validate and resolve character YAML paths to ensure they remain inside `characters`
- update role listing to use `Path.iterdir`

## Testing
- `python3 -m py_compile GPT_RP.py`

------
https://chatgpt.com/codex/tasks/task_e_685cbd1e6ba8832f8279ed6067c1f002