### PR TITLE
Refactor YAML loader

### DIFF
--- a/GPT_RP.py
+++ b/GPT_RP.py
@@ -61,12 +61,13 @@ def load_character_yaml(char_name: str):
     if Path(lc_name).name != lc_name:
         raise HTTPException(status_code=400, detail="非法角色卡路徑！")
 
-    candidates = [CHAR_DIR / f"{lc_name}.yaml", CHAR_DIR / f"{lc_name}.yml"]
-    path = next((p for p in candidates if p.exists()), None)
-    if not path:
+    for ext in (".yaml", ".yml"):
+        candidate = CHAR_DIR / f"{lc_name}{ext}"
+        if candidate.exists():
+            resolved = candidate.resolve()
+            break
+    else:
         raise HTTPException(status_code=404, detail=f"角色卡 {char_name} 不存在！")
-
-    resolved = path.resolve()
     try:
         resolved.relative_to(CHAR_DIR.resolve())
     except ValueError:


### PR DESCRIPTION
## Summary
- refactor `load_character_yaml` to resolve the YAML file as soon as it is found
- remove unnecessary path existence check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685cc3d045d8832fa36b3acad9206f07