### PR TITLE
Add httpx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Create a Python environment and install dependencies from `requirements.txt`:
 ```bash
 pip install -r requirements.txt
 ```
+The requirements include FastAPI, uvicorn, PyYAML, Pydantic, and httpx for HTTP requests.
 
 ## Running the Server
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pyyaml
 pydantic
+httpx


### PR DESCRIPTION
## Summary
- include `httpx` in requirements
- document new dependency in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68678cf11050832fbcadba5f97c1abe1